### PR TITLE
Immediately send visibility update on disableWebViewOptimizations

### DIFF
--- a/android/src/main/java/com/angeloraso/plugins/backgroundmode/BackgroundMode.java
+++ b/android/src/main/java/com/angeloraso/plugins/backgroundmode/BackgroundMode.java
@@ -196,6 +196,9 @@ public class BackgroundMode {
     
     public void disableWebViewOptimizations() {
         mSettings.setDisableWebViewOptimization(true);
+        // Immediately dispatch visibility changed in case the app
+        // has started in the background and is not visible
+        mWebView.dispatchWindowVisibilityChanged(View.VISIBLE);
     }
 
     public boolean checkForegroundPermission() {


### PR DESCRIPTION
Fixes the case where the app launches in the background and never triggers onStop. This can happen with background launches (e.g., during phone boot)

Fixes #3